### PR TITLE
app crashes when user clear the edittext.

### DIFF
--- a/common/src/main/kotlin/com/afollestad/nocknock/utilities/ext/ViewExt.kt
+++ b/common/src/main/kotlin/com/afollestad/nocknock/utilities/ext/ViewExt.kt
@@ -38,7 +38,9 @@ fun EditText.onTextChanged(
 ) {
   addTextChangedListener(object : TextWatcher {
     val callbackRunner = Runnable {
-      cb(text.trim().toString())
+      if(text.trim().toString()!="") {
+        cb(text.trim().toString())
+      }
     }
 
     override fun afterTextChanged(s: Editable?) = Unit


### PR DESCRIPTION
Hi Aidan,

I checked out this project today, after cloning the repository I just run it on my AVD.  As a first step, I thought I should add a site in order to check the workflow. During the process, I just cleared the Edittext all the sudden the app got crashed. I checked the Logcat and found that it's because of the empty string. So I fixed the issue and thought I should create a PR. Please check the code and If you have a better way to resolve this please go ahead.   
            
![screen 1](https://user-images.githubusercontent.com/25472210/49731230-a94a8400-fca0-11e8-9179-16eaf0bcda8f.png)
![screen 2](https://user-images.githubusercontent.com/25472210/49731235-aea7ce80-fca0-11e8-8083-07203d423336.png)
![screen 3](https://user-images.githubusercontent.com/25472210/49731237-b1a2bf00-fca0-11e8-8ca6-c0b09e191999.png)

thank you for this wonderful project.