### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/include_empty_view.xml
+++ b/app/src/main/res/layout/include_empty_view.xml
@@ -2,6 +2,7 @@
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/emptyText"
+    android:textcolor="#000000"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"


### PR DESCRIPTION
The original text color of the component is '#FF6E40', and the contrast between the text color ('#FF6E40') and the background color ('#FFFFFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#000000') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167382296-50b0349f-fe22-451f-89a8-2bd57077913c.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.